### PR TITLE
Make Image Dimensions Configurable

### DIFF
--- a/Model/Config/Source/SizeMode.php
+++ b/Model/Config/Source/SizeMode.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Basecom\LiveSearchImageUrls\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class SizeMode implements OptionSourceInterface
+{
+    public const MODE_AUTO = 'automatic';
+    public const MODE_MANUAL = 'manual';
+
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => self::MODE_AUTO, 'label' => __(ucwords(self::MODE_AUTO))],
+            ['value' => self::MODE_MANUAL, 'label' => __(ucwords(self::MODE_MANUAL))],
+        ];
+    }
+}

--- a/Model/Config/Source/ViewXmlImageTypes.php
+++ b/Model/Config/Source/ViewXmlImageTypes.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Basecom\LiveSearchImageUrls\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Framework\StdLib\ArrayManager;
+use Magento\Framework\View\ConfigInterface;
+
+class ViewXmlImageTypes implements OptionSourceInterface
+{
+    public function __construct(
+        private readonly ArrayManager $arrayManager,
+        private readonly ConfigInterface $viewConfig
+    ) {
+    }
+
+    public function toOptionArray(): array
+    {
+        $imageTypes = [];
+        $viewConfig = $this->viewConfig->getViewConfig(['area' => 'frontend'])->read() ?? [];
+        $imageConfig = $this->arrayManager->get('media/Magento_Catalog/images', $viewConfig) ?? [];
+
+        foreach ($imageConfig as $type => $config) {
+            $suffix = '';
+
+            if (array_key_exists('width', $config)) {
+                $widthSuffix = 'W: ' . $config['width'] . 'px';
+                $heightSuffix = array_key_exists('height', $config)
+                    ? 'H: ' . $config['height'] . 'px'
+                    : 'H: auto';
+
+                $suffix = sprintf('(%s, %s)', $widthSuffix, $heightSuffix);
+            }
+
+            $imageTypes[] = [
+                'value' => $type,
+                'label' => ucwords(str_replace('_', ' ', $type)) . $suffix,
+            ];
+        }
+
+        return $imageTypes;
+    }
+}

--- a/System/ModuleConfig.php
+++ b/System/ModuleConfig.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Basecom\LiveSearchImageUrls\System;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class ModuleConfig
+{
+    private const XML_PATH_RESIZE_MODE = 'storefront_features/image_dimensions/size_mode';
+    private const XML_PATH_RESIZE_IMAGE_ID = 'storefront_features/image_dimensions/image_id';
+    private const XML_PATH_RESIZE_HEIGHT = 'storefront_features/image_dimensions/resize_height';
+    private const XML_PATH_RESIZE_WIDTH = 'storefront_features/image_dimensions/resize_width';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    public function getResizeMode($scopeId = null): ?string
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_RESIZE_MODE, ScopeInterface::SCOPE_STORE, $scopeId);
+    }
+
+    public function getImageId($scopeId = null): ?string
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_RESIZE_IMAGE_ID, ScopeInterface::SCOPE_STORE, $scopeId);
+    }
+
+    public function getResizeHeight($scopeId = null): ?int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_RESIZE_HEIGHT, ScopeInterface::SCOPE_STORE, $scopeId)
+            ?? null;
+    }
+
+    public function getResizeWidth($scopeId = null): ?int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_RESIZE_WIDTH, ScopeInterface::SCOPE_STORE, $scopeId)
+            ?? null;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="storefront_features">
+            <group id="image_dimensions"
+                   translate="label"
+                   sortOrder="100"
+                   showInDefault="1"
+                   showInWebsite="1"
+                   showInStore="1">
+                <label>Image Dimensions</label>
+                <field id="size_mode"
+                       translate="label comment"
+                       type="select"
+                       sortOrder="10"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1"
+                       canRestore="1">
+                    <label>Resize Mode</label>
+                    <comment>
+                        <![CDATA[
+                            Only works on Hyvä Storefronts!
+                            <br>
+                            Auto: Read from theme's view.xml file (recommended).
+                            <br>
+                            Manual: Define custom width and height values.
+                        ]]>
+                    </comment>
+                    <source_model>Basecom\LiveSearchImageUrls\Model\Config\Source\SizeMode</source_model>
+                </field>
+                <field id="image_id"
+                       translate="label"
+                       type="select"
+                       sortOrder="20"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1"
+                       canRestore="1">
+                    <label>Image ID</label>
+                    <source_model>Basecom\LiveSearchImageUrls\Model\Config\Source\ViewXmlImageTypes</source_model>
+                    <depends>
+                        <field id="storefront_features/image_dimensions/size_mode">automatic</field>
+                    </depends>
+                </field>
+                <field id="resize_height"
+                       translate="label"
+                       type="text"
+                       sortOrder="30"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1"
+                       canRestore="1">
+                    <label>Height (px)</label>
+                    <validate>required-entry integer</validate>
+                    <depends>
+                        <field id="storefront_features/image_dimensions/size_mode">manual</field>
+                    </depends>
+                </field>
+                <field id="resize_width"
+                       translate="label"
+                       type="text"
+                       sortOrder="40"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1"
+                       canRestore="1">
+                    <label>Width (px)</label>
+                    <validate>required-entry integer</validate>
+                    <depends>
+                        <field id="storefront_features/image_dimensions/size_mode">manual</field>
+                    </depends>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <storefront_features>
+            <image_dimensions>
+                <size_mode>automatic</size_mode>
+                <image_id>product_page_image_small</image_id>
+                <resize_height>90</resize_height>
+                <resize_width>90</resize_width>
+            </image_dimensions>
+        </storefront_features>
+    </default>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,4 +7,10 @@
                 sortOrder="10"
         />
     </type>
+    <type name="Basecom\LiveSearchImageUrls\Plugin\SetCachedImageUrls">
+        <arguments>
+            <argument name="fallbackHeight" xsi:type="number">90</argument>
+            <argument name="fallbackWidth" xsi:type="number">90</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
# Description
Add some admin configuration options to control the image dimensions when resizing and provide a fallback (configurable via `di.xml`) in case of missing dimensions data.

